### PR TITLE
Fix Arkion dialog tree on BGEE/EET.

### DIFF
--- a/bg1ub/scar/bg1ub_scar.tpa
+++ b/bg1ub/scar/bg1ub_scar.tpa
@@ -1,6 +1,9 @@
 ///// Scar and the Sashenstar's Daughter               \\\\\
 /////        - Scar Quest Extention(s)                 \\\\\
 
+ACTION_IF !GAME_IS ~bgee~ THEN BEGIN
+	COMPILE EVALUATE_BUFFER ~bg1ub/scar/ubscar_classic.d~ USING ~bg1ub/tra/%LANGUAGE%/ubscar.tra~
+END
 COMPILE EVALUATE_BUFFER ~bg1ub/scar/ubscar.d~
 ACTION_IF !GAME_IS ~bgee~ THEN BEGIN
 	COMPILE EVALUATE_BUFFER ~bg1ub/scar/ubscar_fixes.d~

--- a/bg1ub/scar/ubscar.d
+++ b/bg1ub/scar/ubscar.d
@@ -1,14 +1,7 @@
 
 REPLACE_STATE_TRIGGER %tutu_var%ARKION 6 ~Global("HelpArkion","GLOBAL",1)~
 
-
 APPEND %tutu_var%ARKION
-IF WEIGHT #0 ~Global("HelpArkion","GLOBAL",0)
-PartyHasItem("%tutu_scriptbg%MISC79")~ THEN BEGIN EitherBody
-  SAY @0
-  IF ~PartyHasItem("%tutu_scriptbg%MISC79")~ THEN DO ~SetGlobal("HelpArkion","GLOBAL",1) TakePartyItem("%tutu_scriptbg%MISC79") GivePartyGold(250) AddexperienceParty(1800)~ EXIT
-END
-
 IF WEIGHT #0 ~Global("HelpArkion","GLOBAL",0)
 PartyHasItem("UBFEBODY")~ THEN BEGIN NobleBody
   SAY @16

--- a/bg1ub/scar/ubscar_classic.d
+++ b/bg1ub/scar/ubscar_classic.d
@@ -1,0 +1,15 @@
+/*
+EE CHANGES:
+
+EE already includes female bodies as part of it's Arkion quest, thereby the BG1UB entry isn't required. Additionally,
+including it weights it above the response where he would reward for multiple bodies, locking players out from that option.
+
+*/
+
+APPEND %tutu_var%ARKION
+IF WEIGHT #0 ~Global("HelpArkion","GLOBAL",0)
+PartyHasItem("%tutu_scriptbg%MISC79")~ THEN BEGIN EitherBody
+  SAY @0
+  IF ~PartyHasItem("%tutu_scriptbg%MISC79")~ THEN DO ~SetGlobal("HelpArkion","GLOBAL",1) TakePartyItem("%tutu_scriptbg%MISC79") GivePartyGold(250) AddexperienceParty(1800)~ EXIT
+END
+END


### PR DESCRIPTION
EE already includes female bodies as part of it's Arkion quest, thereby
the BG1UB entry isn't required. Additionally, including it weights it
above the response where he would reward for multiple bodies, locking
players out from that option.

Tested against BGT, BGEE, BG1 and EET. (I don't have a Tutu install at hand.)

=======================================

BGT is still bugged though, this entry leaves the journal entry open and the single female body option hides the multiple male delivery option.